### PR TITLE
[147] Ensure read and execute bits are set.

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -10,6 +10,7 @@ USER root
 
 RUN chown -R solr:solr /opt/solr/server/solr/configsets/scholars-discovery
 RUN chmod -R 755 /opt/solr/server/solr/configsets/scholars-discovery
+RUN chmod -R ugo+rx /setup.sh
 
 USER solr
 


### PR DESCRIPTION
resolves #147

Explicitly set the necessary permissions on the `/setup.sh` script.