### PR TITLE
[136] Add complete author list to person.

### DIFF
--- a/solr/conf/managed-schema
+++ b/solr/conf/managed-schema
@@ -258,6 +258,14 @@
       </analyzer>
     </fieldType>
 
+    <!-- Scholars ordered (nestable) whole strings type -->
+    <fieldType name="ordered_whole_strings" class="solr.TextField" omitNorms="true" termVectors="false" termPositions="false" termOffsets="false" sortMissingLast="true" multiValued="true">
+      <analyzer>
+        <charFilter class="solr.PatternReplaceFilterFactory" pattern="^(\d+);;(.*?)(::.*)$" replacement="$2"/>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+      </analyzer>
+    </fieldType>
+
     <!-- Scholars dynamic nested facet field -->
     <dynamicField name="*_nested_facets" type="nested_whole_strings" indexed="true" stored="true" multiValued="true"/>
 

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/DiscoveryConstants.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/DiscoveryConstants.java
@@ -20,6 +20,8 @@ public class DiscoveryConstants {
 
     public static final String NESTED_DELIMITER = "::";
 
+    public static final String ORDERED_DELIMITER = ";;";
+
     public static final String REQUEST_PARAM_DELIMETER = ",";
 
     public static final String PATH_DELIMETER_REGEX = "\\.";

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/annotation/PropertySource.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/annotation/PropertySource.java
@@ -23,4 +23,6 @@ public @interface PropertySource {
 
     boolean relative() default false;
 
+    boolean ordered() default false;
+
 }

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/comparator/OrderedComparator.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/comparator/OrderedComparator.java
@@ -1,0 +1,16 @@
+package edu.tamu.scholars.middleware.discovery.comparator;
+
+import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.ORDERED_DELIMITER;
+
+import java.util.Comparator;
+
+public class OrderedComparator implements Comparator<String> {
+
+    @Override
+    public int compare(String a, String b) {
+        final String[] left = a.split(ORDERED_DELIMITER, 2);
+        final String[] right = b.split(ORDERED_DELIMITER, 2);
+
+        return Integer.valueOf(left[0]).compareTo(Integer.valueOf(right[0]));
+    }
+}

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/Document.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/Document.java
@@ -933,6 +933,14 @@ public class Document extends Common {
         this.advisedBy = advisedBy;
     }
 
+    public List<String> getCompleteAuthorList() {
+        return completeAuthorList;
+    }
+
+    public void setCompleteAuthorList(List<String> completeAuthorList) {
+        this.completeAuthorList =completeAuthorList;
+    }
+
     public List<String> getAuthorList() {
         return authorList;
     }

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/Document.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/Document.java
@@ -341,6 +341,10 @@ public class Document extends Common {
     @PropertySource(template = "document/advisedBy", predicate = "http://www.w3.org/2000/01/rdf-schema#label")
     private List<String> advisedBy;
 
+    @Indexed(type = "ordered_whole_strings")
+    @PropertySource(template = "document/completeAuthorList", predicate = "http://vivo.library.tamu.edu/ontology/TAMU#completeAuthorList", ordered = true)
+    private List<String> completeAuthorList;
+
     @Indexed(type = "whole_strings")
     @PropertySource(template = "document/authorList", predicate = "http://vivo.library.tamu.edu/ontology/TAMU#fullAuthorList")
     private List<String> authorList;

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/serializer/UnwrappingIndividualSerializer.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/serializer/UnwrappingIndividualSerializer.java
@@ -100,22 +100,17 @@ public class UnwrappingIndividualSerializer extends JsonSerializer<Individual> {
                     }
                 } else {
                     if (!value.toString().contains(NESTED_DELIMITER)) {
+
+                        @SuppressWarnings("unchecked")
+                        List<String> values = (List<String>) value;
+
                         if (List.class.isAssignableFrom(field.getType())) {
-                            if (propertySource.ordered()) {
-                                jsonGenerator.writeObjectField(name, sortWithoutPrefix(value));
-                            }
-                            else {
-                                jsonGenerator.writeObjectField(name, value);
-                            }
-                        } else {
-
-                            @SuppressWarnings("unchecked")
-                            List<String> values = (List<String>) value;
-
                             if (propertySource.ordered()) {
                                 values = sortWithoutPrefix(value);
                             }
 
+                            jsonGenerator.writeObjectField(name, values);
+                        } else {
                             jsonGenerator.writeObjectField(nameTransformer.transform(name), values.get(0));
                         }
                     }

--- a/src/main/java/edu/tamu/scholars/middleware/graphql/model/Document.java
+++ b/src/main/java/edu/tamu/scholars/middleware/graphql/model/Document.java
@@ -200,6 +200,8 @@ public class Document extends AbstractNestedDocument {
 
   private String url;
 
+  private List<String> completeAuthorList;
+
   private List<String> authorList;
 
   private List<String> editorList;
@@ -798,6 +800,14 @@ public class Document extends AbstractNestedDocument {
 
   public void setUrl(String url) {
     this.url = url;
+  }
+
+  public List<String> getCompleteAuthorList() {
+    return completeAuthorList;
+  }
+
+  public void setCompleteAuthorList(List<String> completeAuthorList) {
+    this.completeAuthorList = completeAuthorList;
   }
 
   public List<String> getAuthorList() {

--- a/src/main/resources/defaults/displayViews.yml
+++ b/src/main/resources/defaults/displayViews.yml
@@ -1137,6 +1137,7 @@
         - name: complete author list
           template: "defaults/displayViews/documents/overview/completeAuthorList.html"
           field: completeAuthorList
+          paginated: true
           order: 5
         - name: editors
           template: "defaults/displayViews/documents/overview/editors.html"

--- a/src/main/resources/defaults/displayViews.yml
+++ b/src/main/resources/defaults/displayViews.yml
@@ -1134,98 +1134,102 @@
           template: "defaults/displayViews/documents/overview/authorList.html"
           field: authorList
           order: 4
+        - name: complete author list
+          template: "defaults/displayViews/documents/overview/completeAuthorList.html"
+          field: completeAuthorList
+          order: 5
         - name: editors
           template: "defaults/displayViews/documents/overview/editors.html"
           field: editors
-          order: 5
+          order: 6
         - name: editor list (cited editors)
           template: "defaults/displayViews/documents/overview/editorList.html"
           field: editorList
-          order: 6
+          order: 7
         - name: etd chair
           template: "defaults/displayViews/documents/overview/etdChair.html"
           field: etdChairedBy
-          order: 7
+          order: 8
           lazyReferences:
             - etdChairedBy
         - name: capstone (non-thesis) advisor
           template: "defaults/displayViews/documents/overview/advisor.html"
           field: advisedBy
-          order: 8
+          order: 9
           lazyReferences:
             - advisedBy
         - name: translator
           template: "defaults/displayViews/documents/overview/translator.html"
           field: translators
-          order: 9
+          order: 10
         - name: status
           template: "defaults/displayViews/documents/overview/status.html"
           field: status
-          order: 10
+          order: 11
         - name: publication date
           template: "defaults/displayViews/documents/overview/publicationDate.html"
           field: publicationDate
-          order: 11
+          order: 12
         - name: publisher
           template: "defaults/displayViews/documents/overview/publisher.html"
           field: publisher
-          order: 12
+          order: 13
         - name: has subject area
           template: "defaults/displayViews/documents/overview/hasSubjectArea.html"
           field: subjectAreas
-          order: 13
+          order: 14
         - name: has restriction
           template: "defaults/displayViews/documents/overview/hasRestriction.html"
           field: restrictions
-          order: 14
+          order: 15
         - name: has document part
           template: "defaults/displayViews/documents/overview/hasDocumentPart.html"
           field: documentParts
-          order: 15
+          order: 16
         - name: features
           template: "defaults/displayViews/documents/overview/features.html"
           field: features
-          order: 16
+          order: 17
         - name: published in
           template: "defaults/displayViews/documents/overview/publishedIn.html"
           field: publicationVenue
-          order: 17
+          order: 18
           lazyReferences:
             - publicationVenue
         - name: geographic focus
           template: "defaults/displayViews/documents/overview/geographicFocus.html"
           field: geographicFocus
-          order: 18
+          order: 19
         - name: documentation for project or resource
           template: "defaults/displayViews/documents/overview/documentationForProjectOrResource.html"
           field: documentationForProjectOrResource
-          order: 19
+          order: 20
         - name: output of process or event
           template: "defaults/displayViews/documents/overview/outputOfProcessOrEvent.html"
           field: outputOfProcessOrEvent
-          order: 20
+          order: 21
         - name: open educational resource for
           template: "defaults/displayViews/documents/overview/presentedAtEvent.html"
           field: presentedAt
-          order: 21
+          order: 22
           lazyReferences:
             - presentedAt
         - name: keywords
           template: "defaults/displayViews/documents/overview/keywords.html"
           field: keywords
-          order: 22
+          order: 23
         - name: altmetric score
           template: "defaults/displayViews/documents/overview/altmetricScore.html"
           field: altmetricScore
-          order: 23
+          order: 24
         - name: citation count
           template: "defaults/displayViews/documents/overview/citationCount.html"
           field: citationCount
-          order: 24
+          order: 25
         - name: news outlet
           template: "defaults/displayViews/documents/overview/newsOutlet.html"
           field: newsOutlet
-          order: 25
+          order: 26
     - name: Identity
       sections:
         - name: EAN International-Uniform Code Council (EAN-UCC) 13

--- a/src/main/resources/defaults/displayViews/documents/overview/completeAuthorList.html
+++ b/src/main/resources/defaults/displayViews/documents/overview/completeAuthorList.html
@@ -1,9 +1,1 @@
-{{#if completeAuthorList}}
-<ul class="list-unstyled">
-  {{#each completeAuthorList}}
-  <li>
-    <span>{{.}}</span>
-  </li>
-  {{/each}}
-</ul>
-{{/if}}
+<span>{{.}}</span>

--- a/src/main/resources/defaults/displayViews/documents/overview/completeAuthorList.html
+++ b/src/main/resources/defaults/displayViews/documents/overview/completeAuthorList.html
@@ -1,0 +1,9 @@
+{{#if completeAuthorList}}
+<ul class="list-unstyled">
+  {{#each completeAuthorList}}
+  <li>
+    <span>{{.}}</span>
+  </li>
+  {{/each}}
+</ul>
+{{/if}}

--- a/src/main/resources/templates/sparql/document/completeAuthorList.sparql
+++ b/src/main/resources/templates/sparql/document/completeAuthorList.sparql
@@ -1,0 +1,8 @@
+PREFIX tamu: <http://vivo.library.tamu.edu/ontology/TAMU#>
+
+CONSTRUCT {
+    <{{uri}}> tamu:completeAuthorList ?orderedCompleteAuthorList .
+} WHERE {
+    <{{uri}}> tamu:completeAuthorList ?completeAuthorList .
+    BIND( REPLACE(STR(?completeAuthorList), "^\\s*\\[(\\d+)\\]\\s*-\\s*(.+)$", "$1;;$2") as ?orderedCompleteAuthorList ) .
+}


### PR DESCRIPTION
resolves #136 

This does:
- Add solr schema field type `ordered_whole_strings`, based off of `nested_whole_strings`.
- The `ordered_whole_strings` should support nested strings.
- Add `ORDERED_DELIMITER` discovery constant.
- Add boolean annotation property `ordered` to `PropertySource`.
- Add `OrderedComparator` class under a new comparator directory within the discovery directory tree.
- Add `completeAuthorList` to `Document` as an `ordered_whole_strings` array, utilizing the newly added `ordered` `PropertySource`.
- Provide basic implementation for ordering the list and removing the ordering digits.
- Add `completeAuthorList` sparql file.

This takes a simple approach so that future iterations will have an easier time updating this.
The provided sparql regex query is guaranteeing a certain consistency in the output.