### PR TITLE
Removed the skip tests flag so docs can generate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN chown -R ${USER_ID}:${USER_ID} ${SOURCE_DIR}
 USER $USER_NAME
 
 # Build.
-RUN mvn package -DskipTests=true
+RUN mvn package
 
 # Switch to Normal JRE Stage.
 FROM openjdk:11-jre-slim


### PR DESCRIPTION
Resolves #196 

This was happening because the tests were being skipped, which caused the doc snippets to not be generated. This is fixed by removing the skip tests flag from the mvn build command in the dockerfile.