### PR TITLE
Dependency upgrades 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.14</version>
+    <version>2.6.15</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
@@ -29,7 +29,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <log4j2.version>2.17.1</log4j2.version>
+    <log4j2.version>2.17.2</log4j2.version>
     <jena.version>4.9.0</jena.version>
     <solr.version>9.1.1</solr.version>
   </properties>
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.7.0</version><!-- $NO-MVN-MAN-VER$ -->
+      <version>2.8.0</version>
     </dependency>
 
     <dependency>
@@ -172,7 +172,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.22</version>
+      <version>1.24.0</version>
     </dependency>
 
     <dependency>
@@ -231,7 +231,7 @@
     <dependency>
       <groupId>org.passay</groupId>
       <artifactId>passay</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.4</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Unable to upgrade to Spring Boot 3 until `solr-core` provides version using jakarta instead of javax. Otherwise, this PR provides some minor and patch upgrades.