### PR TITLE
Set path to allow any context path

### DIFF
--- a/src/main/java/edu/tamu/scholars/middleware/config/WebSecurityConfig.java
+++ b/src/main/java/edu/tamu/scholars/middleware/config/WebSecurityConfig.java
@@ -135,6 +135,8 @@ public class WebSecurityConfig {
         DefaultCookieSerializer serializer = new DefaultCookieSerializer();
         serializer.setUseHttpOnlyCookie(false);
         serializer.setUseSecureCookie(false);
+        serializer.setCookiePath("/");
+        serializer.setCookieName("SESSION");
         return serializer;
     }
 


### PR DESCRIPTION
# Description

When deployed under a context path different than the UI the session cookie would not be set in the browser. This PR sets the session cookie path to afford any context path.

# Helper Checklist (optional)
> Please ensure the following has been completed.

- [ ] Changes reviewed and are acceptable to the best of your understanding.
- [x] Changes are documented where necessary.
- [x] Contacted code owners to evaluate.
