### PR TITLE
[Issue #412]: Add Datasets subsection and type addition to Document

### DIFF
--- a/src/main/resources/defaults/displayViews.yml
+++ b/src/main/resources/defaults/displayViews.yml
@@ -322,9 +322,22 @@
                 - field: title
                   direction: ASC
               template: "defaults/displayViews/persons/publications/selectedPublications/default.html"
-            - name: Theses
+            - name: Datasets
               field: publications
               order: 6
+              filters:
+                - field: type
+                  value: Dataset
+              sort:
+                - field: publicationDate
+                  direction: DESC
+                  date: true
+                - field: title
+                  direction: ASC
+              template: "defaults/displayViews/persons/publications/selectedPublications/default.html"
+            - name: Theses
+              field: publications
+              order: 7
               filters:
                 - field: type
                   value: Thesis
@@ -337,7 +350,7 @@
               template: "defaults/displayViews/persons/publications/selectedPublications/thesis.html"
             - name: Working Papers
               field: publications
-              order: 7
+              order: 8
               filters:
                 - field: type
                   value: WorkingPaper
@@ -350,7 +363,7 @@
               template: "defaults/displayViews/persons/publications/selectedPublications/default.html"
             - name: Internet Publications
               field: publications
-              order: 8
+              order: 9
               filters:
                 - field: type
                   value: Webpage
@@ -363,7 +376,7 @@
               template: "defaults/displayViews/persons/publications/selectedPublications/internetPublication.html"
             - name: Reports
               field: publications
-              order: 9
+              order: 10
               filters:
                 - field: type
                   value: Report
@@ -376,7 +389,7 @@
               template: "defaults/displayViews/persons/publications/selectedPublications/report.html"
             - name: Reviews
               field: publications
-              order: 10
+              order: 11
               filters:
                 - field: type
                   value: Review
@@ -1439,20 +1452,21 @@
 - name: Documents
   types:
     - AcademicArticle
-    - ConferencePaper
-    - Thesis
-    - Chapter
     - Book
-    - GreyLiterature
-    - Patent
-    - WorkingPaper
-    - NewsRelease
-    - ERO_0000071
     - Capstone
-    - Webpage
+    - Chapter
+    - ConferencePaper
+    - Dataset
+    - GreyLiterature
+    - NewsRelease
+    - Patent
     - Report
     - Review
     - TeachingMaterial
+    - Thesis
+    - Webpage
+    - WorkingPaper
+    - ERO_0000071
   mainContentTemplate: "defaults/displayViews/documents/mainContentTemplate.html"
   rightScanTemplate: "defaults/displayViews/documents/rightScanTemplate.html"
   metaTemplates:


### PR DESCRIPTION
If the default template for the citation is not satisfying the requirements copied below then we will have to create a specific template for datasets. In which we will require all minimal permutations of data possible to check correct rendering of citations. We currently only have one. Which looks to need some data manipulation to correct the ampersand which should be corrected in the triplestore to avoid encodings in the data.

![image](https://github.com/user-attachments/assets/7ea43a22-7ee8-4b36-8fe3-f9c0e06fb1d8)

```
Display on person profile page as APA, similar to Repository Documents/Preprints types:

Author1lastname, A., Author2lastname, B., & FinalAuthorlastname, C. (year). Dataset title.
Links icons: DOI(if available) Open Access(link to Data@TAMU) Citations(if available)

If more than 6 authors, follow APA format:
Authorlastname, A., Authorlastname, B., Authorlastname, C., Authorlastname, D., Authorlastname, E., Authorlastname, F., ... Lastauthorlastname, Z. (year). Dataset title.
Links icons: DOI(if available) Open Access(link to Data@TAMU) Citations(if available)
```

Here are the current templates available for [selectedPublications](https://github.com/TAMULib/scholars-discovery/tree/412-scholarly-works-datasets/src/main/resources/defaults/displayViews/persons/publications/selectedPublications). Datasets are using default.html as described in the [DisplayView](https://github.com/TAMULib/scholars-discovery/blob/412-scholarly-works-datasets/src/main/resources/defaults/displayViews.yml#L337).

Here is what the dataset looks like in VIVO under the persons profile page.

![image](https://github.com/user-attachments/assets/d3291a9f-f0f4-4584-8483-2d68c92b31f4)

Here is the data scholars-discovery is indexing from the RDF for the dataset n60.rdf.

```
<tamu:fullAuthorList>Stvilia, B., Wu, S., &amp;amp; Lee, D. J.&amp;nbsp;</tamu:fullAuthorList>
```

It appears VIVO is sanitizing the data before rendering.

![image](https://github.com/user-attachments/assets/8140ddd5-5a14-4be1-b381-3d42be1e8b1b)


