### PR TITLE
Renamed 'Type' facet to 'People'

### DIFF
--- a/src/main/resources/defaults/directoryViews.yml
+++ b/src/main/resources/defaults/directoryViews.yml
@@ -13,7 +13,7 @@
     - positions.organizations
     - thumbnail
   facets:
-    - name: Type
+    - name: People
       field: type
       type: STRING
       sort: COUNT


### PR DESCRIPTION
# Description
Renamed facet from 'Type' to 'People' as requested in issue #441 .

# Supporting Material
![Code_Qc7kr8PaWy](https://github.com/user-attachments/assets/402feea4-3350-49b7-a224-3aa5407ac97c)
