### PR TITLE
Cookie domain name hotfix

### DIFF
--- a/src/main/java/edu/tamu/scholars/middleware/config/WebSecurityConfig.java
+++ b/src/main/java/edu/tamu/scholars/middleware/config/WebSecurityConfig.java
@@ -60,7 +60,7 @@ public class WebSecurityConfig {
     @Value("${spring.h2.console.enabled:false}")
     private boolean h2ConsoleEnabled;
 
-    @Value("${server.servlet.session.cookie.domain:localhost}")
+    @Value("${server.servlet.session.cookie.domain:library.tamu.edu}")
     private String domainName;
 
     @Autowired

--- a/src/main/java/edu/tamu/scholars/middleware/config/WebSecurityConfig.java
+++ b/src/main/java/edu/tamu/scholars/middleware/config/WebSecurityConfig.java
@@ -9,6 +9,7 @@ import static org.springframework.http.HttpMethod.PUT;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Arrays;
+import java.util.Objects;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,6 +59,9 @@ public class WebSecurityConfig {
 
     @Value("${spring.h2.console.enabled:false}")
     private boolean h2ConsoleEnabled;
+
+    @Value("${server.servlet.session.cookie.domain}")
+    private String domainName;
 
     @Autowired
     private MiddlewareConfig config;
@@ -148,6 +152,10 @@ public class WebSecurityConfig {
         serializer.setUseSecureCookie(false);
         serializer.setCookiePath("/");
         serializer.setCookieName("SESSION");
+        if (Objects.nonNull(domainName)) {
+            serializer.setDomainName(domainName);
+        }
+
         return serializer;
     }
 

--- a/src/main/java/edu/tamu/scholars/middleware/config/WebSecurityConfig.java
+++ b/src/main/java/edu/tamu/scholars/middleware/config/WebSecurityConfig.java
@@ -60,7 +60,7 @@ public class WebSecurityConfig {
     @Value("${spring.h2.console.enabled:false}")
     private boolean h2ConsoleEnabled;
 
-    @Value("${server.servlet.session.cookie.domain}")
+    @Value("${server.servlet.session.cookie.domain:localhost}")
     private String domainName;
 
     @Autowired
@@ -152,9 +152,7 @@ public class WebSecurityConfig {
         serializer.setUseSecureCookie(false);
         serializer.setCookiePath("/");
         serializer.setCookieName("SESSION");
-        if (Objects.nonNull(domainName)) {
-            serializer.setDomainName(domainName);
-        }
+        serializer.setDomainName(domainName);
 
         return serializer;
     }

--- a/src/main/java/edu/tamu/scholars/middleware/config/WebSecurityConfig.java
+++ b/src/main/java/edu/tamu/scholars/middleware/config/WebSecurityConfig.java
@@ -9,7 +9,6 @@ import static org.springframework.http.HttpMethod.PUT;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Arrays;
-import java.util.Objects;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
# Description
Explicitly set the cookie domain. This is to allow UI and server being on different subdomains.
