### PR TITLE
Added `or` helper to display the Researcher Identifier label.

### DIFF
--- a/src/main/resources/defaults/displayViews/persons/asideTemplate.html
+++ b/src/main/resources/defaults/displayViews/persons/asideTemplate.html
@@ -82,12 +82,14 @@
   </div>
   {{/if}}
 
+  {{#if (or orcidId isiResearcherId scopusId dimensionsId twitter)}}
   <div>
     <hr />
     <div class="id-row">
       <span class="label">Researcher Identifiers</span>
     </div>
   </div>
+  {{/if}}
 
   {{#if orcidId}}
   <div class="id-row">


### PR DESCRIPTION
```
{{#if (or orcidId isiResearcherId scopusId dimensionsId twitter)}}
  <div>
   <hr />
   <div class="id-row">
    <span class="label">Researcher Identifiers</span>
   </div>
  </div>
{{/if}}
```

Tested locally. Attached are snapshots of conditional rendering:
a. With no researcher identifiers:
<img width="1310" height="1224" alt="William_ResearcherIdentifierSection" src="https://github.com/user-attachments/assets/5f0a0ea3-48e5-4589-8e4d-c243fa005aa9" />
b. With researcher identifiers:
<img width="1311" height="1221" alt="Doug_ResearcherIdentifierSection" src="https://github.com/user-attachments/assets/3ba41185-a6f8-4c02-bd5f-b58761b6f7ea" />


on `scholars angular` end: - checked out `sprint11-staging` branch  where scholars-embed-utilities points to : `0.4.2`
