### PR TITLE
470 export section people

### DIFF
--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndexDocumentRepo.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndexDocumentRepo.java
@@ -17,6 +17,7 @@ import edu.tamu.scholars.middleware.discovery.argument.FilterArg;
 import edu.tamu.scholars.middleware.discovery.argument.HighlightArg;
 import edu.tamu.scholars.middleware.discovery.argument.QueryArg;
 import edu.tamu.scholars.middleware.discovery.model.AbstractIndexDocument;
+import edu.tamu.scholars.middleware.discovery.model.Individual;
 import edu.tamu.scholars.middleware.discovery.response.DiscoveryAcademicAge;
 import edu.tamu.scholars.middleware.discovery.response.DiscoveryFacetAndHighlightPage;
 import edu.tamu.scholars.middleware.discovery.response.DiscoveryNetwork;
@@ -67,5 +68,7 @@ public interface IndexDocumentRepo<D extends AbstractIndexDocument> {
         QueryArg query,
         List<FilterArg> filters
     );
+
+    public List<Individual> getIndividualsData(String id);
 
 }

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndexDocumentRepo.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndexDocumentRepo.java
@@ -69,6 +69,6 @@ public interface IndexDocumentRepo<D extends AbstractIndexDocument> {
         List<FilterArg> filters
     );
 
-    public List<Individual> getIndividualsData(String id);
+    public List<Individual> getIndividualsData(String id, String fieldName);
 
 }

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndividualRepo.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndividualRepo.java
@@ -153,7 +153,7 @@ public class IndividualRepo implements IndexDocumentRepo<Individual> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public List<Individual> getIndividualsData(String id) {
+    public List<Individual> getIndividualsData(String id, String fieldName) {
 
         if (id.isEmpty()) {
             return Collections.emptyList();
@@ -162,7 +162,7 @@ public class IndividualRepo implements IndexDocumentRepo<Individual> {
         try {
             SolrQueryBuilder queryBuilder = new SolrQueryBuilder()
                 .withFilters(Arrays.asList(
-                    FilterArg.of("id", Optional.of(id), Optional.empty(), Optional.empty())
+                    FilterArg.of(ID, Optional.of(id), Optional.empty(), Optional.empty())
                 ))
                 .withRows(1);
 
@@ -174,7 +174,7 @@ public class IndividualRepo implements IndexDocumentRepo<Individual> {
 
             SolrDocument document = response.getResults().get(0);
 
-            List<String> orgPeopleList = (List<String>) document.getFieldValue("people");
+            List<String> orgPeopleList = (List<String>) document.getFieldValue(fieldName);
             if (orgPeopleList.isEmpty()) {
                 return Collections.emptyList();
             }
@@ -244,55 +244,6 @@ public class IndividualRepo implements IndexDocumentRepo<Individual> {
         } catch (IOException | SolrServerException e) {
             throw new SolrRequestException("Failed to search documents", e);
         }
-    }
-
-    public Flux<Individual>exportSection(QueryArg query, Sort sort, String view, String type, String id) {
-        logger.info("\n\n\n\nexportSection  = \n\nview={}, \n\n type={}, \n\n\nquery={}", view, type, query);
-        logger.info("\n\n orgId: {}", id );
-
-        SolrQueryBuilder builder = new SolrQueryBuilder()
-            .withQuery(query)
-            .withSort(sort);
-
-        return Flux.create(emitter -> {
-            try {
-                solrClient.queryAndStreamResponse(collectionName, builder.query(), new StreamingResponseCallback() {
-                    private final AtomicLong remaining = new AtomicLong(0);
-                    private final AtomicBoolean docListInfoReceived  = new AtomicBoolean(false);
-
-                    @Override
-                    public void streamSolrDocument(SolrDocument document) {
-                        logger.info("{} \n {}: streamSolrDocument collectionName", collectionName, builder.getId());
-                        Individual individual = Individual.from(document);
-                        logger.debug("{}: streamSolrDocument: {}", builder.getId(), individual);
-                        emitter.next(individual);
-
-                        long numRemaining = remaining.decrementAndGet();
-                        logger.debug("{}: csv export streamSolrDocument remaining: {}", builder.getId(), numRemaining);
-                        if (numRemaining == 0 && docListInfoReceived.get()) {
-                            logger.info("{}: csv export streamSolrDocument COMPLETE", builder.getId());
-                            emitter.complete();
-                        }
-                    }
-
-                    @Override
-                    public void streamDocListInfo(long numFound, long start, Float maxScore) {
-                        logger.debug("{}: csv export streamDocListInfo {} {} {}", builder.getId(), numFound, start, maxScore);
-
-                        remaining.set(numFound);
-                        docListInfoReceived.set(true);
-
-                        if (numFound == 0) {
-                            logger.info("{}: csv export streamDocListInfo COMPLETE", builder.getId());
-                            emitter.complete();
-                        }
-                    }
-
-                });
-            } catch (IOException | SolrServerException e) {
-                throw new SolrRequestException("Failed to stream csv export", e);
-            }
-        });
     }
 
     @Override

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndividualRepo.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndividualRepo.java
@@ -235,7 +235,6 @@ public class IndividualRepo implements IndexDocumentRepo<Individual> {
 
         try {
             QueryResponse response = solrClient.query(collectionName, builder.query());
-            System.out.println("\n\n\n QueryResponse response: "+ response.getResults() + "\n\n\n");
             List<Individual> individuals = response.getResults()
                 .stream()
                 .map(Individual::from)
@@ -248,8 +247,7 @@ public class IndividualRepo implements IndexDocumentRepo<Individual> {
     }
 
     public Flux<Individual>exportSection(QueryArg query, Sort sort, String view, String type, String id) {
-        logger.info("\n\n\n\nexportSection  = \n\nview={}, \n\n type={}, \n\n\nquery={}", view, type, query);
-        logger.info("\n\n orgId: {}", id );
+        logger.info("\n\n\n\nexportSection  = \n\nview={}, \n\n type={}  \n\n id={}, \n\n\nquery={}", view, type, query, id);
 
         SolrQueryBuilder builder = new SolrQueryBuilder()
             .withQuery(query)
@@ -380,7 +378,6 @@ public class IndividualRepo implements IndexDocumentRepo<Individual> {
                         dataNetwork.countLink(v1);
                     }
                     for (String v2 : values) {
-                        // prefer id as source
                         if (v2.endsWith(id)) {
                             dataNetwork.map(iid, v2, v1);
                         } else {

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndividualRepo.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndividualRepo.java
@@ -247,7 +247,8 @@ public class IndividualRepo implements IndexDocumentRepo<Individual> {
     }
 
     public Flux<Individual>exportSection(QueryArg query, Sort sort, String view, String type, String id) {
-        logger.info("\n\n\n\nexportSection  = \n\nview={}, \n\n type={}  \n\n id={}, \n\n\nquery={}", view, type, query, id);
+        logger.info("\n\n\n\nexportSection  = \n\nview={}, \n\n type={}, \n\n\nquery={}", view, type, query);
+        logger.info("\n\n orgId: {}", id );
 
         SolrQueryBuilder builder = new SolrQueryBuilder()
             .withQuery(query)

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndividualRepo.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndividualRepo.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -47,6 +48,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
+
 import reactor.core.publisher.Flux;
 
 import edu.tamu.scholars.middleware.discovery.argument.BoostArg;
@@ -148,6 +150,43 @@ public class IndividualRepo implements IndexDocumentRepo<Individual> {
         }
     }
 
+    public List<Individual> findPeopleByOrganizationId(String orgId) {
+
+        if (orgId.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        try {
+            SolrQueryBuilder orgQueryBuilder = new SolrQueryBuilder()
+                .withFilters(Arrays.asList(
+                    FilterArg.of("id", Optional.of(orgId), Optional.empty(), Optional.empty())
+                ))
+                .withRows(1);
+
+            QueryResponse orgResponse = solrClient.query(collectionName, orgQueryBuilder.query());
+
+            if (orgResponse.getResults().isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            SolrDocument orgDoc = orgResponse.getResults().get(0);
+
+            List<String> orgPeopleList = (List<String>) orgDoc.getFieldValue("people");
+            if (orgPeopleList.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<String> orgPeopleListIds = orgPeopleList.stream()
+                .map(s -> s.contains("::") ? s.split("::")[1] : s)
+                .toList();
+            List<Individual> individuals = findByIdIn(orgPeopleListIds, new ArrayList<>(),Sort.unsorted(),orgPeopleListIds.size());
+
+            return individuals;
+
+        } catch (IOException | SolrServerException e) {
+            throw new SolrRequestException("Failed to fetch people for organization " + orgId, e);
+        }
+    }
+
     @Override
     public List<Individual> findByIdIn(List<String> ids, List<FilterArg> filters, Sort sort, int limit) {
         try {
@@ -155,9 +194,7 @@ public class IndividualRepo implements IndexDocumentRepo<Individual> {
                 .withFilters(filters)
                 .withSort(sort)
                 .withRows(limit);
-
-            JsonQueryRequest jsonRequest = builder.jsonQuery(ids);
-
+            JsonQueryRequest jsonRequest = builder.jsonQuery(new ArrayList<>(ids));
             QueryResponse response = jsonRequest.process(solrClient, collectionName);
 
             return response.getResults()
@@ -198,7 +235,7 @@ public class IndividualRepo implements IndexDocumentRepo<Individual> {
 
         try {
             QueryResponse response = solrClient.query(collectionName, builder.query());
-
+            System.out.println("\n\n\n QueryResponse response: "+ response.getResults() + "\n\n\n");
             List<Individual> individuals = response.getResults()
                 .stream()
                 .map(Individual::from)
@@ -208,6 +245,55 @@ public class IndividualRepo implements IndexDocumentRepo<Individual> {
         } catch (IOException | SolrServerException e) {
             throw new SolrRequestException("Failed to search documents", e);
         }
+    }
+
+    public Flux<Individual>exportSection(QueryArg query, Sort sort, String view, String type, String id) {
+        logger.info("\n\n\n\nexportSection  = \n\nview={}, \n\n type={}, \n\n\nquery={}", view, type, query);
+        logger.info("\n\n orgId: {}", id );
+
+        SolrQueryBuilder builder = new SolrQueryBuilder()
+            .withQuery(query)
+            .withSort(sort);
+
+        return Flux.create(emitter -> {
+            try {
+                solrClient.queryAndStreamResponse(collectionName, builder.query(), new StreamingResponseCallback() {
+                    private final AtomicLong remaining = new AtomicLong(0);
+                    private final AtomicBoolean docListInfoReceived  = new AtomicBoolean(false);
+
+                    @Override
+                    public void streamSolrDocument(SolrDocument document) {
+                        logger.info("{} \n {}: streamSolrDocument collectionName", collectionName, builder.getId());
+                        Individual individual = Individual.from(document);
+                        logger.debug("{}: streamSolrDocument: {}", builder.getId(), individual);
+                        emitter.next(individual);
+
+                        long numRemaining = remaining.decrementAndGet();
+                        logger.debug("{}: csv export streamSolrDocument remaining: {}", builder.getId(), numRemaining);
+                        if (numRemaining == 0 && docListInfoReceived.get()) {
+                            logger.info("{}: csv export streamSolrDocument COMPLETE", builder.getId());
+                            emitter.complete();
+                        }
+                    }
+
+                    @Override
+                    public void streamDocListInfo(long numFound, long start, Float maxScore) {
+                        logger.debug("{}: csv export streamDocListInfo {} {} {}", builder.getId(), numFound, start, maxScore);
+
+                        remaining.set(numFound);
+                        docListInfoReceived.set(true);
+
+                        if (numFound == 0) {
+                            logger.info("{}: csv export streamDocListInfo COMPLETE", builder.getId());
+                            emitter.complete();
+                        }
+                    }
+
+                });
+            } catch (IOException | SolrServerException e) {
+                throw new SolrRequestException("Failed to stream csv export", e);
+            }
+        });
     }
 
     @Override

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndividualRepo.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/IndividualRepo.java
@@ -65,6 +65,7 @@ import edu.tamu.scholars.middleware.discovery.response.DiscoveryAcademicAge;
 import edu.tamu.scholars.middleware.discovery.response.DiscoveryFacetAndHighlightPage;
 import edu.tamu.scholars.middleware.discovery.response.DiscoveryNetwork;
 import edu.tamu.scholars.middleware.discovery.response.DiscoveryQuantityDistribution;
+import edu.tamu.scholars.middleware.export.utility.ExtractIdUtility;
 import edu.tamu.scholars.middleware.utility.DateFormatUtility;
 
 /**
@@ -150,40 +151,39 @@ public class IndividualRepo implements IndexDocumentRepo<Individual> {
         }
     }
 
-    public List<Individual> findPeopleByOrganizationId(String orgId) {
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<Individual> getIndividualsData(String id) {
 
-        if (orgId.isEmpty()) {
+        if (id.isEmpty()) {
             return Collections.emptyList();
         }
 
         try {
-            SolrQueryBuilder orgQueryBuilder = new SolrQueryBuilder()
+            SolrQueryBuilder queryBuilder = new SolrQueryBuilder()
                 .withFilters(Arrays.asList(
-                    FilterArg.of("id", Optional.of(orgId), Optional.empty(), Optional.empty())
+                    FilterArg.of("id", Optional.of(id), Optional.empty(), Optional.empty())
                 ))
                 .withRows(1);
 
-            QueryResponse orgResponse = solrClient.query(collectionName, orgQueryBuilder.query());
+            QueryResponse response = solrClient.query(collectionName, queryBuilder.query());
 
-            if (orgResponse.getResults().isEmpty()) {
+            if (response.getResults().isEmpty()) {
                 return Collections.emptyList();
             }
 
-            SolrDocument orgDoc = orgResponse.getResults().get(0);
+            SolrDocument document = response.getResults().get(0);
 
-            List<String> orgPeopleList = (List<String>) orgDoc.getFieldValue("people");
+            List<String> orgPeopleList = (List<String>) document.getFieldValue("people");
             if (orgPeopleList.isEmpty()) {
                 return Collections.emptyList();
             }
-            List<String> orgPeopleListIds = orgPeopleList.stream()
-                .map(s -> s.contains("::") ? s.split("::")[1] : s)
-                .toList();
-            List<Individual> individuals = findByIdIn(orgPeopleListIds, new ArrayList<>(),Sort.unsorted(),orgPeopleListIds.size());
+            List<String> orgPeopleListIds = ExtractIdUtility.extractIds(orgPeopleList);
 
-            return individuals;
+            return findByIdIn(orgPeopleListIds, new ArrayList<>(),Sort.unsorted(),orgPeopleListIds.size());
 
         } catch (IOException | SolrServerException e) {
-            throw new SolrRequestException("Failed to fetch people for organization " + orgId, e);
+            throw new SolrRequestException("Failed to fetch people for organization " + id, e);
         }
     }
 

--- a/src/main/java/edu/tamu/scholars/middleware/export/controller/IndividualExportController.java
+++ b/src/main/java/edu/tamu/scholars/middleware/export/controller/IndividualExportController.java
@@ -107,15 +107,15 @@ public class IndividualExportController implements RepresentationModelProcessor<
         }
     }
 
-    @GetMapping("/individual/{id}/export/section")
+    @GetMapping(value = "/individual/{id}/export", params = "view")
     public ResponseEntity<StreamingResponseBody> exportSectionPeople(
         @PathVariable String id,
         @RequestParam(required = false, defaultValue = "People") String view,
         @RequestParam(required = false, defaultValue = "csv") String type,
-        List<ExportArg> export
+        @RequestParam(required = false) List<ExportArg> export
         ) throws UnknownExporterTypeException {
             Exporter exporter = exporterRegistry.getExporter(type);
-            List<Individual> individuals = repo.findPeopleByOrganizationId(id);
+            List<Individual> individuals = repo.getIndividualsData(id);
             return ResponseEntity.ok()
                 .header(CONTENT_DISPOSITION, exporter.contentDisposition(FilenameUtility.normalizeExportFilename(view)))
                 .header(CONTENT_TYPE, exporter.contentType())

--- a/src/main/java/edu/tamu/scholars/middleware/export/controller/IndividualExportController.java
+++ b/src/main/java/edu/tamu/scholars/middleware/export/controller/IndividualExportController.java
@@ -108,14 +108,14 @@ public class IndividualExportController implements RepresentationModelProcessor<
     }
 
     @GetMapping(value = "/individual/{id}/export", params = "view")
-    public ResponseEntity<StreamingResponseBody> exportSectionPeople(
+    public ResponseEntity<StreamingResponseBody> exportSection(
         @PathVariable String id,
         @RequestParam(required = false, defaultValue = "People") String view,
         @RequestParam(required = false, defaultValue = "csv") String type,
         @RequestParam(required = false) List<ExportArg> export
         ) throws UnknownExporterTypeException {
             Exporter exporter = exporterRegistry.getExporter(type);
-            List<Individual> individuals = repo.getIndividualsData(id);
+            List<Individual> individuals = repo.getIndividualsData(id, view.toLowerCase());
             return ResponseEntity.ok()
                 .header(CONTENT_DISPOSITION, exporter.contentDisposition(FilenameUtility.normalizeExportFilename(view)))
                 .header(CONTENT_TYPE, exporter.contentType())

--- a/src/main/java/edu/tamu/scholars/middleware/export/controller/IndividualExportController.java
+++ b/src/main/java/edu/tamu/scholars/middleware/export/controller/IndividualExportController.java
@@ -12,11 +12,14 @@ import java.util.Objects;
 import java.util.Optional;
 
 import jakarta.persistence.EntityNotFoundException;
+import reactor.core.publisher.Flux;
+
 import org.springframework.context.annotation.Lazy;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,11 +33,12 @@ import edu.tamu.scholars.middleware.discovery.model.Individual;
 import edu.tamu.scholars.middleware.discovery.model.Organization;
 import edu.tamu.scholars.middleware.discovery.model.Person;
 import edu.tamu.scholars.middleware.discovery.model.repo.IndividualRepo;
+import edu.tamu.scholars.middleware.export.argument.ExportArg;
 import edu.tamu.scholars.middleware.export.exception.UnauthorizedExportException;
 import edu.tamu.scholars.middleware.export.exception.UnknownExporterTypeException;
 import edu.tamu.scholars.middleware.export.service.Exporter;
 import edu.tamu.scholars.middleware.export.service.ExporterRegistry;
-
+import edu.tamu.scholars.middleware.export.utility.FilenameUtility;
 
 /**
  * REST controller for exporting
@@ -101,6 +105,21 @@ public class IndividualExportController implements RepresentationModelProcessor<
         } catch(NullPointerException npe) {
             throw new IllegalArgumentException("Request body for IDs is missing or invalid", npe);
         }
+    }
+
+    @GetMapping("/individual/{id}/export/section")
+    public ResponseEntity<StreamingResponseBody> exportSectionPeople(
+        @PathVariable String id,
+        @RequestParam(required = false, defaultValue = "People") String view,
+        @RequestParam(required = false, defaultValue = "csv") String type,
+        List<ExportArg> export
+        ) throws UnknownExporterTypeException {
+            Exporter exporter = exporterRegistry.getExporter(type);
+            List<Individual> individuals = repo.findPeopleByOrganizationId(id);
+            return ResponseEntity.ok()
+                .header(CONTENT_DISPOSITION, exporter.contentDisposition(FilenameUtility.normalizeExportFilename(view)))
+                .header(CONTENT_TYPE, exporter.contentType())
+                .body(exporter.streamIndividuals(Flux.fromIterable(individuals), export));
     }
 
     @Override

--- a/src/main/java/edu/tamu/scholars/middleware/export/service/Exporter.java
+++ b/src/main/java/edu/tamu/scholars/middleware/export/service/Exporter.java
@@ -27,13 +27,6 @@ public interface Exporter {
         ));
     }
 
-    public default StreamingResponseBody streamIndividuals(Individual individual, List<ExportArg> export) {
-        throw new UnsupportedExporterTypeException(String.format(
-            "%s exporter does not support export field exports",
-            type()
-        ));
-    }
-
     public default StreamingResponseBody streamIndividuals(List<Individual> individuals, String name) {
         throw new UnsupportedExporterTypeException(String.format(
             "%s exporter does not support exporting multiple individuals",
@@ -44,6 +37,13 @@ public interface Exporter {
     public default StreamingResponseBody streamIndividual(Individual individual, String name) {
         throw new UnsupportedExporterTypeException(String.format(
             "%s exporter does not support individual templated exports",
+            type()
+        ));
+    }
+
+    public default StreamingResponseBody streamIndividuals(Individual individual, List<ExportArg> export) {
+        throw new UnsupportedExporterTypeException(String.format(
+            "%s exporter does not support export field exports",
             type()
         ));
     }

--- a/src/main/java/edu/tamu/scholars/middleware/export/service/Exporter.java
+++ b/src/main/java/edu/tamu/scholars/middleware/export/service/Exporter.java
@@ -27,6 +27,13 @@ public interface Exporter {
         ));
     }
 
+    public default StreamingResponseBody streamIndividuals(Individual individual, List<ExportArg> export) {
+        throw new UnsupportedExporterTypeException(String.format(
+            "%s exporter does not support export field exports",
+            type()
+        ));
+    }
+
     public default StreamingResponseBody streamIndividuals(List<Individual> individuals, String name) {
         throw new UnsupportedExporterTypeException(String.format(
             "%s exporter does not support exporting multiple individuals",

--- a/src/main/java/edu/tamu/scholars/middleware/export/utility/ExtractIdUtility.java
+++ b/src/main/java/edu/tamu/scholars/middleware/export/utility/ExtractIdUtility.java
@@ -1,0 +1,36 @@
+package edu.tamu.scholars.middleware.export.utility;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 
+ */
+public class ExtractIdUtility {
+
+    private ExtractIdUtility() {
+
+    }
+
+    /**
+     * Converts list of string with '::' prefix into a list of ids.
+     */
+    public static List<String> extractIds(List<String> inputs) {
+        if (inputs == null || inputs.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return inputs.stream()
+                     .map(s -> s == null || s.isEmpty() ? null : (s.contains("::") ? s.split("::")[1] : s))
+                     .collect(Collectors.toList());
+    }
+
+    // /**
+    //  * Convenience method for a single string.
+    //  */
+    // public static String extractId(String input) {
+    //     if (input == null || input.isEmpty()) return null;
+    //     return input.contains("::") ? input.split("::")[1] : input;
+    // }
+
+}

--- a/src/main/java/edu/tamu/scholars/middleware/export/utility/ExtractIdUtility.java
+++ b/src/main/java/edu/tamu/scholars/middleware/export/utility/ExtractIdUtility.java
@@ -25,12 +25,4 @@ public class ExtractIdUtility {
                      .collect(Collectors.toList());
     }
 
-    // /**
-    //  * Convenience method for a single string.
-    //  */
-    // public static String extractId(String input) {
-    //     if (input == null || input.isEmpty()) return null;
-    //     return input.contains("::") ? input.split("::")[1] : input;
-    // }
-
 }

--- a/src/main/java/edu/tamu/scholars/middleware/view/model/DisplaySectionView.java
+++ b/src/main/java/edu/tamu/scholars/middleware/view/model/DisplaySectionView.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
@@ -50,6 +51,13 @@ public class DisplaySectionView extends FieldView {
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private List<DisplaySubsectionView> subsections;
 
+    @JoinColumn(name = "export_view_id")
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    private List<ExportView> exportViews;
+
+    @ElementCollection
+    private List<ExportField> export;
+
     public DisplaySectionView() {
         super();
         hidden = false;
@@ -59,6 +67,24 @@ public class DisplaySectionView extends FieldView {
         requiredFields = new ArrayList<String>();
         lazyReferences = new ArrayList<String>();
         subsections = new ArrayList<DisplaySubsectionView>();
+        exportViews = new ArrayList<>();
+        export = new ArrayList<ExportField>();
+    }
+
+    public List<ExportView> getExportViews() {
+        return exportViews;
+    }
+
+    public void setExportViews(List<ExportView> exportViews) {
+        this.exportViews = exportViews;
+    }
+
+    public List<ExportField> getExport() {
+        return export;
+    }
+
+    public void setExport(List<ExportField> export) {
+        this.export = export;
     }
 
     public boolean isHidden() {

--- a/src/main/java/edu/tamu/scholars/middleware/view/model/DisplaySectionView.java
+++ b/src/main/java/edu/tamu/scholars/middleware/view/model/DisplaySectionView.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
@@ -67,16 +66,7 @@ public class DisplaySectionView extends FieldView {
         requiredFields = new ArrayList<String>();
         lazyReferences = new ArrayList<String>();
         subsections = new ArrayList<DisplaySubsectionView>();
-        exportViews = new ArrayList<>();
         export = new ArrayList<ExportField>();
-    }
-
-    public List<ExportView> getExportViews() {
-        return exportViews;
-    }
-
-    public void setExportViews(List<ExportView> exportViews) {
-        this.exportViews = exportViews;
     }
 
     public List<ExportField> getExport() {

--- a/src/main/java/edu/tamu/scholars/middleware/view/model/DisplaySectionView.java
+++ b/src/main/java/edu/tamu/scholars/middleware/view/model/DisplaySectionView.java
@@ -50,10 +50,6 @@ public class DisplaySectionView extends FieldView {
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private List<DisplaySubsectionView> subsections;
 
-    @JoinColumn(name = "export_view_id")
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
-    private List<ExportView> exportViews;
-
     @ElementCollection
     private List<ExportField> export;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -194,7 +194,7 @@ spring:
     password: scholars
   jpa:
     generate-ddl: false
-    hibernate.ddl-auto: update
+    hibernate.ddl-auto: none
     open-in-view: false
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -194,7 +194,7 @@ spring:
     password: scholars
   jpa:
     generate-ddl: false
-    hibernate.ddl-auto: none
+    hibernate.ddl-auto: update
     open-in-view: false
     properties:
       hibernate:

--- a/src/main/resources/defaults/discoveryViews/people/default.html
+++ b/src/main/resources/defaults/discoveryViews/people/default.html
@@ -26,7 +26,7 @@
     </div>
     <div>
       {{#each researchAreas}}
-        <span><a href="display/{{id}}">{{#if ./snippet}}{{{./snippet}}}{{else}}{{label}}</a>{{/if}}{{#if @last}}{{else}}, {{/if}}</span>
+      <span><a href="display/{{id}}">{{#if ./snippet}}{{{./snippet}}}{{else}}{{label}}</a>{{/if}}{{#if @last}}{{else}}, {{/if}}</span>
       {{/each}}
     </div>
     {{/if}}

--- a/src/main/resources/defaults/discoveryViews/people/default.html
+++ b/src/main/resources/defaults/discoveryViews/people/default.html
@@ -24,14 +24,27 @@
     <div class="mt-1">
       <span class="label">Research Areas:</span>
     </div>
-    <div>
-      {{#each researchAreas}}
-      <span><a href="display/{{id}}">{{#if ./snippet}}{{{./snippet}}}{{else}}{{label}}</a>{{/if}}{{#if @last}}{{else}}, {{/if}}</span>
-      {{/each}}
+    <div class="research-areas-wrapper">
+      <div class="research-areas-list clamped">
+        {{#each researchAreas}}
+          <span><a href="display/{{id}}">{{#if ./snippet}}{{{./snippet}}}{{else}}{{label}}</a>{{/if}}{{#if @last}}{{else}}, {{/if}}</span>
+        {{/each}}
+      </div>
+      <a href="#" class="toggle-more" onclick="toggleResearchAreas(this); return false;">more...</a>
     </div>
     {{/if}}
   </div>
 </div>
+
+<script>
+  function toggleResearchAreas(link) {
+    const wrapper = link.closest('.research-areas-wrapper');
+    const list = wrapper.querySelector('.research-areas-list');
+    const isExpanded = list.classList.toggle('expanded');
+    link.textContent = isExpanded ? 'less' : 'more...';
+  }
+</script>
+
 <style>
   .highlighted em {
     background: #E3D67F;

--- a/src/main/resources/defaults/discoveryViews/people/default.html
+++ b/src/main/resources/defaults/discoveryViews/people/default.html
@@ -24,26 +24,14 @@
     <div class="mt-1">
       <span class="label">Research Areas:</span>
     </div>
-    <div class="research-areas-wrapper">
-      <div class="research-areas-list clamped">
-        {{#each researchAreas}}
-          <span><a href="display/{{id}}">{{#if ./snippet}}{{{./snippet}}}{{else}}{{label}}</a>{{/if}}{{#if @last}}{{else}}, {{/if}}</span>
-        {{/each}}
-      </div>
-      <a href="#" class="toggle-more" onclick="toggleResearchAreas(this); return false;">more...</a>
+    <div>
+      {{#each researchAreas}}
+        <span><a href="display/{{id}}">{{#if ./snippet}}{{{./snippet}}}{{else}}{{label}}</a>{{/if}}{{#if @last}}{{else}}, {{/if}}</span>
+      {{/each}}
     </div>
     {{/if}}
   </div>
 </div>
-
-<script>
-  function toggleResearchAreas(link) {
-    const wrapper = link.closest('.research-areas-wrapper');
-    const list = wrapper.querySelector('.research-areas-list');
-    const isExpanded = list.classList.toggle('expanded');
-    link.textContent = isExpanded ? 'less' : 'more...';
-  }
-</script>
 
 <style>
   .highlighted em {

--- a/src/main/resources/defaults/displayViews.yml
+++ b/src/main/resources/defaults/displayViews.yml
@@ -1398,10 +1398,10 @@
               valuePath: emailAddress
             - columnHeader: Orcid
               valuePath: orcidId
-            - columnHeader: First name
-              valuePath: firstName
             - columnHeader: Last name
               valuePath: lastName
+            - columnHeader: First name
+              valuePath: firstName
             - columnHeader: Preferred title
               valuePath: preferredTitle
             - columnHeader: Position

--- a/src/main/resources/defaults/displayViews.yml
+++ b/src/main/resources/defaults/displayViews.yml
@@ -1393,6 +1393,13 @@
           template: "defaults/displayViews/organizations/affiliation/people.html"
           field: people
           order: 2
+          export:
+            - columnHeader: First name
+              valuePath: firstName
+            - columnHeader: Last name
+              valuePath: lastName
+            - columnHeader: Preferred title
+              valuePath: preferredTitle
           subsections:
             - name: People
               field: people

--- a/src/main/resources/defaults/displayViews.yml
+++ b/src/main/resources/defaults/displayViews.yml
@@ -1394,12 +1394,22 @@
           field: people
           order: 2
           export:
+            - columnHeader: TAMU email
+              valuePath: emailAddress
+            - columnHeader: Orcid
+              valuePath: orcidId
             - columnHeader: First name
               valuePath: firstName
             - columnHeader: Last name
               valuePath: lastName
             - columnHeader: Preferred title
               valuePath: preferredTitle
+            - columnHeader: Position
+              valuePath: positions
+            - columnHeader: Department
+              valuePath: positions.organizations
+            - columnHeader: scholars uri
+              valuePath: individual
           subsections:
             - name: People
               field: people

--- a/src/main/resources/defaults/displayViews.yml
+++ b/src/main/resources/defaults/displayViews.yml
@@ -1395,7 +1395,7 @@
           order: 2
           export:
             - columnHeader: TAMU email
-              valuePath: emailAddress
+              valuePath: email
             - columnHeader: Orcid
               valuePath: orcidId
             - columnHeader: Last name
@@ -1408,7 +1408,7 @@
               valuePath: positions
             - columnHeader: Department
               valuePath: positions.organizations
-            - columnHeader: scholars uri
+            - columnHeader: Scholars uri
               valuePath: individual
           subsections:
             - name: People

--- a/src/main/resources/defaults/displayViews/persons/identity/orcidId.html
+++ b/src/main/resources/defaults/displayViews/persons/identity/orcidId.html
@@ -1,1 +1,1 @@
-<span>Work In Progress</span>
+<span>{{orcidId}}</span>


### PR DESCRIPTION
# Description

 Added organization section export functionality for People view

 - Added endpoint: /individual/{id}/export?view=People in `IndividualExportController` to export view: people associated  with an organization

 - Implemented `getIndividualsData(id)` method to get related individuals by passing Organization id.

 - Added `streamIndividuals` for CSV exporter using to stream people data.

 - Added `export` property to `DisplayViews` to support custom export columns.

 - Updated display yml with desired export columns - `TAMU email`, `Orcid`, `Last name`, `First name`, `Preferred title`, `Position`, `Department` and `Scholars uri`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Procedures

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
