### PR TITLE
Line break for streetAddress in mailing address template.

### DIFF
--- a/src/main/resources/defaults/displayViews/persons/contact/mailingAddress.html
+++ b/src/main/resources/defaults/displayViews/persons/contact/mailingAddress.html
@@ -1,3 +1,7 @@
-<div><span>{{streetAddress}}</span></div>
+<div>
+  {{#eachSplit streetAddress ";"}}
+    <span>{{.}}</span><br />
+  {{/eachSplit}}
+</div>
 <div><span>{{locality}}, {{region}} {{postalCode}}</span></div>
 <div><span>{{country}}</span></div>


### PR DESCRIPTION
# Description

Utilized handlebar helper method 'eachSplit' to achieve line break in streetAddress property present in the mailingAddress template.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Procedures

Tested this on local set up as seen in the snapshot attached.
<img width="1001" height="970" alt="Screenshot 2025-10-24 at 1 03 16 PM" src="https://github.com/user-attachments/assets/bee5987b-e1ae-4377-897e-e815cb87e390" />

