### PR TITLE
Add people to export result

### DIFF
--- a/src/main/java/edu/tamu/scholars/middleware/config/model/ExportConfig.java
+++ b/src/main/java/edu/tamu/scholars/middleware/config/model/ExportConfig.java
@@ -19,7 +19,7 @@ public class ExportConfig {
 
     private String individualBaseUri = "http://localhost:4200/display";
 
-    private Map<String, String> personTypeMapping = new HashMap<>();
+    private Map<String, String> personTypes = new HashMap<>();
 
     public String getIndividualKey() {
         return individualKey;

--- a/src/main/java/edu/tamu/scholars/middleware/config/model/ExportConfig.java
+++ b/src/main/java/edu/tamu/scholars/middleware/config/model/ExportConfig.java
@@ -19,7 +19,7 @@ public class ExportConfig {
 
     private String individualBaseUri = "http://localhost:4200/display";
 
-    private Map<String, String> personTypes = new HashMap<>();
+    private Map<String, String> personType = new HashMap<>();
 
     public String getIndividualKey() {
         return individualKey;
@@ -37,18 +37,12 @@ public class ExportConfig {
         this.individualBaseUri = individualBaseUri;
     }
 
-    public Map<String, String> getPersonTypeMapping() {
-        if (personTypeMapping == null || personTypeMapping.isEmpty()) {
-            personTypeMapping = new HashMap<>();
-            personTypeMapping.put("GraduateStudent", "Student Researcher");
-            personTypeMapping.put("FacultyMember", "Faculty Member");
-            personTypeMapping.put("NonFacultyAcademic", "Non Faculty Academic");
-        }
-        return personTypeMapping;
+    public Map<String, String> getPersonType() {
+        return personType;
     }
 
-    public void setPersonTypeMapping(Map<String, String> personTypeMapping) {
-        this.personTypeMapping = personTypeMapping;
+    public void setPersonType(Map<String, String> personType) {
+        this.personType = personType;
     }
 
 }

--- a/src/main/java/edu/tamu/scholars/middleware/config/model/ExportConfig.java
+++ b/src/main/java/edu/tamu/scholars/middleware/config/model/ExportConfig.java
@@ -1,5 +1,8 @@
 package edu.tamu.scholars.middleware.config.model;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +19,8 @@ public class ExportConfig {
 
     private String individualBaseUri = "http://localhost:4200/display";
 
+    private Map<String, String> personTypeMapping = new HashMap<>();
+
     public String getIndividualKey() {
         return individualKey;
     }
@@ -30,6 +35,20 @@ public class ExportConfig {
 
     public void setIndividualBaseUri(String individualBaseUri) {
         this.individualBaseUri = individualBaseUri;
+    }
+
+    public Map<String, String> getPersonTypeMapping() {
+        if (personTypeMapping == null || personTypeMapping.isEmpty()) {
+            personTypeMapping = new HashMap<>();
+            personTypeMapping.put("GraduateStudent", "Student Researcher");
+            personTypeMapping.put("FacultyMember", "Faculty Member");
+            personTypeMapping.put("NonFacultyAcademic", "Non Faculty Academic");
+        }
+        return personTypeMapping;
+    }
+
+    public void setPersonTypeMapping(Map<String, String> personTypeMapping) {
+        this.personTypeMapping = personTypeMapping;
     }
 
 }

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/DiscoveryConstants.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/DiscoveryConstants.java
@@ -39,6 +39,8 @@ public class DiscoveryConstants {
 
     public static final String PARENTHESES_TEMPLATE = "(%s)";
 
+    public static final String SPACE_STRING = " ";
+
     public static final int MAX_PER_TYPE = 16777216;
 
     public static final int MAX_SYNCED_IDS = 65536;

--- a/src/main/java/edu/tamu/scholars/middleware/export/service/CsvExporter.java
+++ b/src/main/java/edu/tamu/scholars/middleware/export/service/CsvExporter.java
@@ -1,20 +1,16 @@
 package edu.tamu.scholars.middleware.export.service;
 
 import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.NESTED_DELIMITER;
-import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.SPACE_STRING;
-
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.WordUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
@@ -127,8 +123,7 @@ public class CsvExporter implements Exporter {
                 Object value = content.get(property);
                 if (property.equals("type")) {
 
-                    @SuppressWarnings("unchecked")
-                    List<String> values = (List<String>) value;
+                    List<String> values = asStringList(value);
 
                     if (!values.isEmpty()) {
                         value = values.stream()
@@ -139,8 +134,7 @@ public class CsvExporter implements Exporter {
 
                 if (List.class.isAssignableFrom(value.getClass())) {
 
-                    @SuppressWarnings("unchecked")
-                    List<String> values = (List<String>) value;
+                    List<String> values = asStringList(value);
 
                     if (!values.isEmpty()) {
                         data = String.join(DELIMITER, values.stream()
@@ -159,31 +153,27 @@ public class CsvExporter implements Exporter {
         return row;
     }
 
+    @SuppressWarnings("unchecked")
+    private List<String> asStringList(Object value) {
+        return (List<String>) value;
+    }
+
     private String serialize(String value) {
         return value.contains(NESTED_DELIMITER)
             ? value.substring(0, value.indexOf(NESTED_DELIMITER))
             : value;
     }
 
-    private String capitalize(String text) {
-        if (text == null || text.isEmpty()) {
-            return text;
-        }
-        return text.substring(0, 1).toUpperCase() + text.substring(1);
-    }
-
     private String formatPersonType(String type) {
         if (type == null || type.isEmpty()) {
             return type;
         }
-        String mapped = config.getPersonTypeMapping().get(type);
-        if (!mapped.equals(type)) return mapped;
 
-        String result = Arrays.stream(type.replaceAll("([a-z])([A-Z])", "$1 $2").split(SPACE_STRING))
-                        .map(this::capitalize)
-                        .collect(Collectors.joining(SPACE_STRING));
+        if (config.getPersonType().containsKey(type)) {
+            return config.getPersonType().get(type);
+        }
 
-        return result;
+        return WordUtils.capitalizeFully(type.replaceAll("([a-z])([A-Z])", "$1 $2"));
     }
 
 }

--- a/src/main/java/edu/tamu/scholars/middleware/export/service/CsvExporter.java
+++ b/src/main/java/edu/tamu/scholars/middleware/export/service/CsvExporter.java
@@ -119,7 +119,6 @@ public class CsvExporter implements Exporter {
             String data = StringUtils.EMPTY;
 
             if (content.containsKey(property)) {
-
                 Object value = content.get(property);
                 if (property.equals("type")) {
 
@@ -133,7 +132,6 @@ public class CsvExporter implements Exporter {
                 }
 
                 if (List.class.isAssignableFrom(value.getClass())) {
-
                     List<String> values = asStringList(value);
 
                     if (!values.isEmpty()) {

--- a/src/main/java/edu/tamu/scholars/middleware/export/service/CsvExporter.java
+++ b/src/main/java/edu/tamu/scholars/middleware/export/service/CsvExporter.java
@@ -1,13 +1,16 @@
 package edu.tamu.scholars.middleware.export.service;
 
 import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.NESTED_DELIMITER;
+import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.SPACE_STRING;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
@@ -111,6 +114,7 @@ public class CsvExporter implements Exporter {
         Map<String, Object> content = individual.getContent();
         List<Object> row = new ArrayList<>();
         for (String property : properties) {
+
             if (property.equals(config.getIndividualKey())) {
                 row.add(String.format("%s/%s", config.getIndividualBaseUri(), individual.getId()));
                 continue;
@@ -121,6 +125,17 @@ public class CsvExporter implements Exporter {
             if (content.containsKey(property)) {
 
                 Object value = content.get(property);
+                if (property.equals("type")) {
+
+                    @SuppressWarnings("unchecked")
+                    List<String> values = (List<String>) value;
+
+                    if (!values.isEmpty()) {
+                        value = values.stream()
+                            .map(this::formatPersonType)
+                            .toList();
+                    }
+                }
 
                 if (List.class.isAssignableFrom(value.getClass())) {
 
@@ -148,6 +163,27 @@ public class CsvExporter implements Exporter {
         return value.contains(NESTED_DELIMITER)
             ? value.substring(0, value.indexOf(NESTED_DELIMITER))
             : value;
+    }
+
+    private String capitalize(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        return text.substring(0, 1).toUpperCase() + text.substring(1);
+    }
+
+    private String formatPersonType(String type) {
+        if (type == null || type.isEmpty()) {
+            return type;
+        }
+        String mapped = config.getPersonTypeMapping().get(type);
+        if (!mapped.equals(type)) return mapped;
+
+        String result = Arrays.stream(type.replaceAll("([a-z])([A-Z])", "$1 $2").split(SPACE_STRING))
+                        .map(this::capitalize)
+                        .collect(Collectors.joining(SPACE_STRING));
+
+        return result;
     }
 
 }

--- a/src/main/java/edu/tamu/scholars/middleware/export/service/CsvExporter.java
+++ b/src/main/java/edu/tamu/scholars/middleware/export/service/CsvExporter.java
@@ -121,7 +121,6 @@ public class CsvExporter implements Exporter {
             if (content.containsKey(property)) {
                 Object value = content.get(property);
                 if (property.equals("type")) {
-
                     List<String> values = asStringList(value);
 
                     if (!values.isEmpty()) {
@@ -133,7 +132,6 @@ public class CsvExporter implements Exporter {
 
                 if (List.class.isAssignableFrom(value.getClass())) {
                     List<String> values = asStringList(value);
-
                     if (!values.isEmpty()) {
                         data = String.join(DELIMITER, values.stream()
                             .map(this::serialize)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,6 +69,10 @@ middleware:
   export:
     individualKey: individual
     individualBaseUri: ${ui.url}/display
+    person-type:
+      GraduateStudent: "Student Researcher"
+      FacultyMember: "Faculty Member"
+      NonFacultyAcademic: "Non Faculty Academic"
 
 solr:
   host: http://localhost:8983/solr

--- a/src/main/resources/defaults/directoryViews.yml
+++ b/src/main/resources/defaults/directoryViews.yml
@@ -67,6 +67,8 @@
       valuePath: positions.organizations
     - columnHeader: Individual
       valuePath: individual
+    - columnHeader: People
+      valuePath: type
   index:
     field: name_sort
     opKey: STARTS_WITH

--- a/src/main/resources/defaults/discoveryViews.yml
+++ b/src/main/resources/defaults/discoveryViews.yml
@@ -114,6 +114,8 @@
       valuePath: individual
     - columnHeader: ORCID
       valuePath: orcidId
+    - columnHeader: People
+      valuePath: type
 
 - name: Research Overview
   layout: LIST

--- a/src/main/resources/defaults/displayViews.yml
+++ b/src/main/resources/defaults/displayViews.yml
@@ -1412,6 +1412,8 @@
               valuePath: positions.organizations
             - columnHeader: Scholars uri
               valuePath: individual
+            - columnHeader: People
+              valuePath: type
           subsections:
             - name: People
               field: people


### PR DESCRIPTION
# Description

Resolves #505 
 - Adds `People` to export results.  
 - Raw data is now displayed as intended - example, the literal: `FacultyMember` appears as `Faculty Member`, `NonFacultyAcademic` as `Non Faculty Academic`, and `GraduateStudent` as `Student Researcher`.

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)
# Testing Procedures

Tested on local set up.
below are the 3 scenarios:
Faculty Member
<img width="1522" height="333" alt="Screenshot 2025-11-10 at 12 07 56 PM" src="https://github.com/user-attachments/assets/3dccfd9a-2d7e-4974-a269-2e537d685cd9" />

Non Faculty Academic
<img width="1221" height="144" alt="Screenshot 2025-11-10 at 12 03 57 PM" src="https://github.com/user-attachments/assets/095a21cd-d80f-4b26-92df-eb83d5602788" />

Student Researcher
<img width="1151" height="131" alt="Screenshot 2025-11-10 at 12 00 22 PM" src="https://github.com/user-attachments/assets/c95f9d33-3bf9-4873-a8aa-e3185c3b6c78" />
