### PR TITLE
Added `label` to DataAnalyticsView response fields. Tests are passing successfully.

### DIFF
--- a/src/test/java/edu/tamu/scholars/middleware/service/HttpServiceTest.java
+++ b/src/test/java/edu/tamu/scholars/middleware/service/HttpServiceTest.java
@@ -19,7 +19,6 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
 import org.apache.http.StatusLine;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.CloseableHttpClient;

--- a/src/test/java/edu/tamu/scholars/middleware/view/controller/DataAndAnalyticsViewControllerTest.java
+++ b/src/test/java/edu/tamu/scholars/middleware/view/controller/DataAndAnalyticsViewControllerTest.java
@@ -47,6 +47,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                     "dataAndAnalyticsViews/create",
                     requestFields(
                         describeDataAndAnalyticsView.withField("name", "The name of the Data And Analytics View."),
+                        describeDataAndAnalyticsView.withField("label", "The label of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("layout", "The layout of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("type", "The container type of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withSubsection("templates", "The result templates of the Data And Analytics View."),
@@ -64,6 +65,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                     ),
                     responseFields(
                         describeDataAndAnalyticsView.withField("name", "The name of the Data And Analytics View."),
+                        describeDataAndAnalyticsView.withField("label", "The label of the Data and Analytics View."),
                         describeDataAndAnalyticsView.withField("layout", "The layout of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("type", "The container type of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withSubsection("templates", "The result templates of the Data And Analytics View."),
@@ -96,6 +98,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                     requestFields(
                         describeDataAndAnalyticsView.withField("id", "The Data And Analytics View id."),
                         describeDataAndAnalyticsView.withField("name", "The name of the Data And Analytics View."),
+                        describeDataAndAnalyticsView.withField("label", "The label of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("layout", "The layout of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("type", "The container type of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withSubsection("templates", "The result templates of the Data And Analytics View."),
@@ -113,6 +116,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                     ),
                     responseFields(
                         describeDataAndAnalyticsView.withField("name", "The name of the Data And Analytics View."),
+                        describeDataAndAnalyticsView.withField("label", "The label of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("layout", "The layout of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("type", "The container type of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withSubsection("templates", "The result templates of the Data And Analytics View."),
@@ -152,6 +156,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                             queryParameters(
                                 describeDataAndAnalyticsView.withParameter("id", "The Data And Analytics View id.").optional(),
                                 describeDataAndAnalyticsView.withParameter("name", "The name of the Data And Analytics View.").optional(),
+                                describeDataAndAnalyticsView.withParameter("label", "The label of the Data And Analytics View.").optional(),
                                 describeDataAndAnalyticsView.withParameter("layout", "The layout of the Data And Analytics View.").optional(),
                                 describeDataAndAnalyticsView.withParameter("type", "The container type of the Data And Analytics View.").optional(),
                                 describeDataAndAnalyticsView.withParameter("templates", "The result templates of the Data And Analytics View.").optional(),
@@ -169,6 +174,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                             ),
                             responseFields(
                                 describeDataAndAnalyticsView.withField("name", "The name of the Data And Analytics View."),
+                                describeDataAndAnalyticsView.withField("label", "The label of the Data And Analytics View."),
                                 describeDataAndAnalyticsView.withField("layout", "The layout of the Data And Analytics View."),
                                 describeDataAndAnalyticsView.withField("type", "The container type of the Data And Analytics View."),
                                 describeDataAndAnalyticsView.withSubsection("templates", "The result templates of the Data And Analytics View."),
@@ -208,6 +214,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                         ),
                         responseFields(
                             describeDataAndAnalyticsView.withField("name", "The name of the Data And Analytics View."),
+                            describeDataAndAnalyticsView.withField("label", "The label of the Data And Analytics View."),
                             describeDataAndAnalyticsView.withField("layout", "The layout of the Data And Analytics View."),
                             describeDataAndAnalyticsView.withField("type", "The container type of the Data And Analytics View."),
                             describeDataAndAnalyticsView.withSubsection("templates", "The result templates of the Data And Analytics View."),


### PR DESCRIPTION


# Description

Added `label` to DataAndAnalyticsView response field.

The DataAndAnalyticsView endpoints - create, update and patch now has a `label` field
in the response payload. 
The tests were failing as the field was not included - now that the `label` field has been added - the tests are passing.

# Testing Procedures

Successful build.
