### PR TITLE
Hot Fix 519: Switch to Java 21 in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 # Settings.
+ARG JAVA_VERSION=21
 ARG USER_ID=3001
 ARG USER_NAME=scholars
 ARG HOME_DIR=/$USER_NAME
 ARG SOURCE_DIR=$HOME_DIR/source
 
 # Maven stage.
-FROM maven:3-eclipse-temurin-21-alpine AS maven
+FROM maven:3-eclipse-temurin-${JAVA_VERSION}-alpine AS maven
 ARG USER_ID
 ARG USER_NAME
 ARG HOME_DIR
 ARG SOURCE_DIR
+ARG MAVEN_COMMANDS="-DskipTests -Dcheckstyle.skip=true -Ddependency-check.skip=true -Djacoco.skip=true -Dcoveralls.skip=true -Dmaven.javadoc.skip=true"
 
 # Create the group (use a high ID to attempt to avoid conflits).
 RUN addgroup -g $USER_ID $USER_NAME
@@ -36,10 +38,10 @@ RUN chown -R ${USER_ID}:${USER_ID} ${SOURCE_DIR}
 USER $USER_NAME
 
 # Build.
-RUN mvn package
+RUN mvn package ${MAVEN_COMMANDS}
 
 # Switch to Normal JRE Stage.
-FROM eclipse-temurin:21-alpine
+FROM eclipse-temurin:${JAVA_VERSION}-alpine
 ARG USER_ID
 ARG USER_NAME
 ARG HOME_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG HOME_DIR=/$USER_NAME
 ARG SOURCE_DIR=$HOME_DIR/source
 
 # Maven stage.
-FROM maven:3-eclipse-temurin-17-alpine AS maven
+FROM maven:3-eclipse-temurin-21-alpine AS maven
 ARG USER_ID
 ARG USER_NAME
 ARG HOME_DIR
@@ -39,7 +39,7 @@ USER $USER_NAME
 RUN mvn package
 
 # Switch to Normal JRE Stage.
-FROM eclipse-temurin:17-alpine
+FROM eclipse-temurin:21-alpine
 ARG USER_ID
 ARG USER_NAME
 ARG HOME_DIR


### PR DESCRIPTION
# Description

Resolves #519 .

Change to Java21 in `Dockerfile`.

Provide a variable `JAVA_VERSION` that defaults to 21 instead of explicitly using 21.

Provide a `MAVEN_COMMANDS` to reduce the build time for local development.
Set `MAVEN_COMMANDS` to an empty string in order to operate using the default manner.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Procedures

No testing yet.
