### PR TITLE
Hot Fix 492: Add Editorial Articles in Person Profile View.

### DIFF
--- a/src/main/resources/defaults/displayViews.yml
+++ b/src/main/resources/defaults/displayViews.yml
@@ -337,6 +337,19 @@
                 - field: title
                   direction: ASC
               template: "defaults/displayViews/persons/publications/selectedPublications/default.html"
+            - name: Editorial Articles
+              field: publications
+              order: 1
+              filters:
+                - field: type
+                  value: EditorialArticle
+              sort:
+                - field: publicationDate
+                  direction: DESC
+                  date: true
+                - field: title
+                  direction: ASC
+              template: "defaults/displayViews/persons/publications/selectedPublications/default.html"
             - name: Theses
               field: publications
               order: 7

--- a/src/main/resources/templates/helpers.js
+++ b/src/main/resources/templates/helpers.js
@@ -139,6 +139,7 @@ Handlebars.registerHelper('toSubsectionTypeLabel', function (value) {
     if (value) {
         switch (value) {
             case "AcademicArticle": return "Academic Articles";
+            case "EditorialArticle": return "Editorial Articles";
             case "Book": return "Books";
             case "Chapter": return "Chapters";
             case "ConferencePaper": return "Conference Papers";

--- a/src/test/java/edu/tamu/scholars/middleware/service/HttpServiceTest.java
+++ b/src/test/java/edu/tamu/scholars/middleware/service/HttpServiceTest.java
@@ -19,7 +19,6 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
 import org.apache.http.StatusLine;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.CloseableHttpClient;

--- a/src/test/java/edu/tamu/scholars/middleware/view/controller/DataAndAnalyticsViewControllerTest.java
+++ b/src/test/java/edu/tamu/scholars/middleware/view/controller/DataAndAnalyticsViewControllerTest.java
@@ -47,6 +47,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                     "dataAndAnalyticsViews/create",
                     requestFields(
                         describeDataAndAnalyticsView.withField("name", "The name of the Data And Analytics View."),
+                        describeDataAndAnalyticsView.withField("label", "The label of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("layout", "The layout of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("type", "The container type of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withSubsection("templates", "The result templates of the Data And Analytics View."),
@@ -64,6 +65,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                     ),
                     responseFields(
                         describeDataAndAnalyticsView.withField("name", "The name of the Data And Analytics View."),
+                        describeDataAndAnalyticsView.withField("label", "The label of the Data and Analytics View."),
                         describeDataAndAnalyticsView.withField("layout", "The layout of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("type", "The container type of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withSubsection("templates", "The result templates of the Data And Analytics View."),
@@ -96,6 +98,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                     requestFields(
                         describeDataAndAnalyticsView.withField("id", "The Data And Analytics View id."),
                         describeDataAndAnalyticsView.withField("name", "The name of the Data And Analytics View."),
+                        describeDataAndAnalyticsView.withField("label", "The label of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("layout", "The layout of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("type", "The container type of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withSubsection("templates", "The result templates of the Data And Analytics View."),
@@ -113,6 +116,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                     ),
                     responseFields(
                         describeDataAndAnalyticsView.withField("name", "The name of the Data And Analytics View."),
+                        describeDataAndAnalyticsView.withField("label", "The label of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("layout", "The layout of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withField("type", "The container type of the Data And Analytics View."),
                         describeDataAndAnalyticsView.withSubsection("templates", "The result templates of the Data And Analytics View."),
@@ -152,6 +156,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                             queryParameters(
                                 describeDataAndAnalyticsView.withParameter("id", "The Data And Analytics View id.").optional(),
                                 describeDataAndAnalyticsView.withParameter("name", "The name of the Data And Analytics View.").optional(),
+                                describeDataAndAnalyticsView.withParameter("label", "The label of the Data And Analytics View.").optional(),
                                 describeDataAndAnalyticsView.withParameter("layout", "The layout of the Data And Analytics View.").optional(),
                                 describeDataAndAnalyticsView.withParameter("type", "The container type of the Data And Analytics View.").optional(),
                                 describeDataAndAnalyticsView.withParameter("templates", "The result templates of the Data And Analytics View.").optional(),
@@ -169,6 +174,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                             ),
                             responseFields(
                                 describeDataAndAnalyticsView.withField("name", "The name of the Data And Analytics View."),
+                                describeDataAndAnalyticsView.withField("label", "The label of the Data And Analytics View."),
                                 describeDataAndAnalyticsView.withField("layout", "The layout of the Data And Analytics View."),
                                 describeDataAndAnalyticsView.withField("type", "The container type of the Data And Analytics View."),
                                 describeDataAndAnalyticsView.withSubsection("templates", "The result templates of the Data And Analytics View."),
@@ -208,6 +214,7 @@ class DataAndAnalyticsViewControllerTest extends ResourceViewIntegrationTest<Dat
                         ),
                         responseFields(
                             describeDataAndAnalyticsView.withField("name", "The name of the Data And Analytics View."),
+                            describeDataAndAnalyticsView.withField("label", "The label of the Data And Analytics View."),
                             describeDataAndAnalyticsView.withField("layout", "The layout of the Data And Analytics View."),
                             describeDataAndAnalyticsView.withField("type", "The container type of the Data And Analytics View."),
                             describeDataAndAnalyticsView.withSubsection("templates", "The result templates of the Data And Analytics View."),


### PR DESCRIPTION
# Description

The **Editorial Articles** is added below the **Dataset**.

The `default.html` view is selected, however, I would not that I investigated using something similar to the **Academic Articles** view.
The **Academic Articles** view is identical, except for the title, which is being printed as raw HTML, no escaping.

I further investigated the reason for this and I found the following:
  - https://github.com/TAMULib/scholars-discovery/commit/19052ee1b90a052d1e9abd9dab1a7429def6bf66
  - https://github.com/TAMULib/scholars-discovery/pull/159
  - https://github.com/TAMULib/scholars-discovery/issues/145
  - https://github.com/TAMULib/scholars-discovery/pull/184
  - https://github.com/TAMULib/scholars-discovery/issues/177

The commit above lacks any documentation but GitHub associates the pull request (159).
The pull request (159) associates the referenced issue (145).
The issue (145) appears to not relate to the actual changes made.
Instead, the correct pull request is likely 184 with associated issue 177.

The only description provided is in the issue title: "Correct person's academic article publication outlet ampersand encoding".
This is likely why `{{{` is being used.

This gives me concern that the default behavior is double escaping data.
However, to favor security practices, I have opted to use the default.
We can address the double-escape situation as discovered.

The handle bar helpers is also updated to handle `EditorialArticle` as instead `Editorial Articles`.

I looked into the unit tests.
After investigating the unit tests, I have opted to not write any given the complexity of the data.
I will have to do further investigation of the unit tests to better handle this in the future.

This also brings in a bug fix (from #515) for the unit tests from the current active sprint so that unit tests pass.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Testing Procedures

No testing yet other than running the unit tests.

Update: Testing was performed via deployment onto DEV and visual observation of desired functionality.
