### PR TITLE
Added expand collapse feature to research section

### DIFF
--- a/src/main/resources/defaults/displayViews/organizations/mainContentTemplate.html
+++ b/src/main/resources/defaults/displayViews/organizations/mainContentTemplate.html
@@ -36,21 +36,27 @@
     font-weight: 550;
     margin-right: 2px;
   }
+
   .research-areas {
     display: block;
   }
+
   .research-areas .expanded-view {
     display: none;
   }
+
   .research-areas .collapsed-view {
     display: inline;
   }
+
   .research-areas[data-expanded="true"] .expanded-view {
     display: inline;
   }
+
   .research-areas[data-expanded="true"] .collapsed-view {
     display: none;
   }
+
   .toggle-btn {
     background: none;
     border: none;

--- a/src/main/resources/defaults/displayViews/organizations/mainContentTemplate.html
+++ b/src/main/resources/defaults/displayViews/organizations/mainContentTemplate.html
@@ -9,12 +9,24 @@
   </span>
 </div>
 {{#if affiliatedResearchAreas}}
-<div class="m2">
-  <div><span class="label">Research Areas:</span></div>
-  <div class="ml-1">
-    {{#each affiliatedResearchAreas}}
-    <span><a href="display/{{id}}">{{label}}</a>{{#if @last}}{{else}}, {{/if}}</span>
-    {{/each}}
+  <div class="m2 research-areas">
+  <div class="label">Research Areas:</div>
+
+  <div class="m1 list">
+    <span class="collapsed-view">
+      {{#each (truncateArray affiliatedResearchAreas 20)}}
+        <a href="display/{{id}}">{{label}}</a>{{#unless @last}}, {{/unless}}
+      {{/each}}
+    </span>
+    <span class="expanded-view">
+      {{#each (showAllItems affiliatedResearchAreas)}}
+        {{#unless @first}}, {{/unless}}<a href="display/{{id}}">{{label}}</a>
+      {{/each}}
+    </span>
+    {{#if (isLong affiliatedResearchAreas 20)}}
+      <button type="button" class="toggle-btn" aria-expanded="false">Show more</button>
+    {{/if}}
+
   </div>
   <hr />
 </div>
@@ -23,5 +35,29 @@
   .label {
     font-weight: 550;
     margin-right: 2px;
+  }
+  .research-areas {
+    display: block;
+  }
+  .research-areas .expanded-view {
+    display: none;
+  }
+  .research-areas .collapsed-view {
+    display: inline;
+  }
+  .research-areas[data-expanded="true"] .expanded-view {
+    display: inline;
+  }
+  .research-areas[data-expanded="true"] .collapsed-view {
+    display: none;
+  }
+  .toggle-btn {
+    background: none;
+    border: none;
+    color: #007acc;
+    cursor: pointer;
+    padding: 0;
+    margin-left: 6px;
+    font-style: bold;
   }
 </style>


### PR DESCRIPTION
# Description

This feature allows expand/collapse behavior in an Organizations' Research Areas section.

- It renders a truncated list of research areas with a configurable `limit` provided in the template.
- It shows full list on user clicking the `Show more` link and toggles back when the `Show less` link is clicked.
- It will only conditionally display toggle when item count exceeds `limit` value.
- Utilized handle bar helper methods and css styles to support collapsed and expanded feature.

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- 
# Testing Procedures

Verified on local set up.
<img width="897" height="478" alt="Screenshot 2026-01-22 at 5 45 59 PM" src="https://github.com/user-attachments/assets/0585d414-a1d5-4bd9-a474-01bcc891e698" />
<img width="1196" height="990" alt="Screenshot 2026-01-22 at 5 46 46 PM" src="https://github.com/user-attachments/assets/759f5753-7f04-49c3-9a27-b43294fd2237" />

