### PR TITLE
Updated link color for consistency with navigation links

### DIFF
--- a/src/main/resources/defaults/displayViews/organizations/mainContentTemplate.html
+++ b/src/main/resources/defaults/displayViews/organizations/mainContentTemplate.html
@@ -60,7 +60,7 @@
   .toggle-btn {
     background: none;
     border: none;
-    color: #007acc;
+    color: var(--navigation-color);
     cursor: pointer;
     padding: 0;
     margin-left: 6px;


### PR DESCRIPTION
# Description
Updated link color for consistency with navigation links

Verified this on local set up and verified with Devang aof the same.
<img width="903" height="408" alt="Screenshot 2026-02-03 at 12 08 15 PM" src="https://github.com/user-attachments/assets/39f94228-0bdb-4322-b7ee-b0a079bbcd30" />

